### PR TITLE
Use SELinux separation instead of privilege

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ fi
 
 # Detect SELinux and add --privileged if necessary
 if docker info --format '{{json .SecurityOptions}}' 2>/dev/null | grep -q 'name=selinux'; then
-    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS --privileged"
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS --security-opt label:disable"
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
Adding `--privileged` on an SELinux system is not a good idea. You should SELinux separation.

This is from https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/.

I also need to add labels to the PWD mount.