### PR TITLE
Add environment var support for image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.
 * **06.07.20:** - Publish docker-compose and docker-cli binaries in Github releases.
 * **01.07.20:** - Release alpine based images at `alpine` tag.
 * **04.06.20:** - Bump docker-cli to 19.03.8, auto-detect python3 version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -131,6 +131,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.
   * **06.07.20:** - Publish docker-compose and docker-cli binaries in Github releases.
   * **01.07.20:** - Release alpine based images at `alpine` tag.
   * **04.06.20:** - Bump docker-cli to 19.03.8, auto-detect python3 version.

--- a/run.sh
+++ b/run.sh
@@ -17,9 +17,8 @@
 
 set -e
 
-VERSION="latest" # can be set to a specific version tag from docker hub, such as "1.25.5", or "alpine"
-IMAGE="linuxserver/docker-compose:$VERSION"
-
+DOCKER_COMPOSE_CONTAINER_VERSION="${DOCKER_COMPOSE_CONTAINER_VERSION-latest}" # can be set to a specific version tag from docker hub, such as "1.25.5", or "alpine"
+IMAGE="linuxserver/docker-compose:$DOCKER_COMPOSE_CONTAINER_VERSION"
 
 # Setup options for connecting to docker host
 if [ -z "$DOCKER_HOST" ]; then

--- a/run.sh
+++ b/run.sh
@@ -13,12 +13,16 @@
 # You can add additional volumes (or any docker run options) using
 # the $COMPOSE_OPTIONS environment variable.
 #
+# You can set a specific image tag from Docker Hub, such as "1.26.2-ls9", or "alpine"
+# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "latest")
+#
 
 
 set -e
 
-DOCKER_COMPOSE_CONTAINER_VERSION="${DOCKER_COMPOSE_CONTAINER_VERSION-latest}" # can be set to a specific version tag from docker hub, such as "1.25.5", or "alpine"
-IMAGE="linuxserver/docker-compose:$DOCKER_COMPOSE_CONTAINER_VERSION"
+# set image tag to latest if not globally set
+DOCKER_COMPOSE_IMAGE_TAG="${DOCKER_COMPOSE_IMAGE_TAG:-latest}"
+IMAGE="linuxserver/docker-compose:$DOCKER_COMPOSE_IMAGE_TAG"
 
 # Setup options for connecting to docker host
 if [ -z "$DOCKER_HOST" ]; then


### PR DESCRIPTION
## Description:

Added support to define the version of the container to run via environment variables.

Closes: #12 

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Benefits of this PR and context:
Allows better use of this script in CICD environments.

## How Has This Been Tested?
I created a docker file and ran it via this command. I used with both DOCKER_COMPOSE_CONTAINER_VERSION set and unset.
