### PR TITLE
Update run.sh formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,23 @@ You can replace the last line with any docker-compose command and argument, whic
 
 ### Recommended method
 
-We provide a very convenient script that allows the docker-compose container to run as if it was installed natively:
+We provide a very convenient script that allows the docker-compose container to run as if it was installed natively.
+
+First run the following commands to setup the script:
+
 ```
+export DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
 sudo curl -L --fail https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 ```
-Running these two commands on your docker host once will let you issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
+
+After running these commands you can issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
+
+The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging our or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
+
+```
+DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
+```
 
 ### Binaries
 
@@ -128,6 +139,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.11.20:** - Update run.sh with formatting changes. IMPORTANT!! This now requires a `DOCKER_COMPOSE_IMAGE_TAG` variable to be set in order to use our image! See https://github.com/linuxserver/docker-docker-compose#recommended-method for instructions!
 * **04.10.20:** - Update run.sh with changes from upstream.
 * **31.08.20:** - Update tox and virtualenv.
 * **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sudo chmod +x /usr/local/bin/docker-compose
 
 After running these commands you can issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
 
-The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging our or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
+The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging out or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
 
 ```
 DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -93,7 +93,7 @@ full_custom_readme: |
 
   After running these commands you can issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
 
-  The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging our or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
+  The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging out or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
 
   ```
   DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -81,9 +81,7 @@ full_custom_readme: |
 
   ### Recommended method
 
-  We provide a very convenient script that allows the docker-compose container to run as if it was installed natively.
-
-  First run the following commands to setup the script:
+  We provide a very convenient script that allows the docker-compose container to run as if it was installed natively:
 
   ```
   export DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
@@ -91,13 +89,7 @@ full_custom_readme: |
   sudo chmod +x /usr/local/bin/docker-compose
   ```
 
-  After running these commands you can issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
-
-  The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging out or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
-
-  ```
-  DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
-  ```
+  Running these two commands on your docker host once will let you issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
 
   ### Binaries
 
@@ -142,7 +134,7 @@ full_custom_readme: |
 
   ## Versions
 
-  * **03.11.20:** - Update run.sh with formatting changes. IMPORTANT!! This now requires a `DOCKER_COMPOSE_IMAGE_TAG` variable to be set in order to use our image! See https://github.com/linuxserver/docker-docker-compose#recommended-method for instructions!
+  * **03.11.20:** - Update run.sh with formatting changes.
   * **04.10.20:** - Update run.sh with changes from upstream.
   * **31.08.20:** - Update tox and virtualenv.
   * **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -84,7 +84,6 @@ full_custom_readme: |
   We provide a very convenient script that allows the docker-compose container to run as if it was installed natively:
 
   ```
-  export DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
   sudo curl -L --fail https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose
   ```
@@ -134,7 +133,7 @@ full_custom_readme: |
 
   ## Versions
 
-  * **03.11.20:** - Update run.sh with formatting changes.
+  * **17.12.20:** - Update run.sh with formatting changes.
   * **04.10.20:** - Update run.sh with changes from upstream.
   * **31.08.20:** - Update tox and virtualenv.
   * **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -81,12 +81,23 @@ full_custom_readme: |
 
   ### Recommended method
 
-  We provide a very convenient script that allows the docker-compose container to run as if it was installed natively:
+  We provide a very convenient script that allows the docker-compose container to run as if it was installed natively.
+
+  First run the following commands to setup the script:
+
   ```
+  export DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
   sudo curl -L --fail https://raw.githubusercontent.com/linuxserver/docker-docker-compose/master/run.sh -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose
   ```
-  Running these two commands on your docker host once will let you issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
+
+  After running these commands you can issue commands such as `docker-compose up -d` and the docker-compose container will do its job behind the scenes.
+
+  The `DOCKER_COMPOSE_IMAGE_TAG` variable needs to be made persistent in order to continue using our image after logging our or rebooting. To do this you will need to edit `/etc/environment` and add or set the following variable:
+
+  ```
+  DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest
+  ```
 
   ### Binaries
 
@@ -131,6 +142,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **03.11.20:** - Update run.sh with formatting changes. IMPORTANT!! This now requires a `DOCKER_COMPOSE_IMAGE_TAG` variable to be set in order to use our image! See https://github.com/linuxserver/docker-docker-compose#recommended-method for instructions!
   * **04.10.20:** - Update run.sh with changes from upstream.
   * **31.08.20:** - Update tox and virtualenv.
   * **31.07.20:** - Add support for global env var `DOCKER_COMPOSE_IMAGE_TAG` in the `run.sh` script.

--- a/run.sh
+++ b/run.sh
@@ -68,4 +68,4 @@ if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name
 fi
 
 # shellcheck disable=SC2086
-exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${DOCKER_COMPOSE_IMAGE_TAG:-docker/compose:1.27.4}" "$@"
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${DOCKER_COMPOSE_IMAGE_TAG:-ghcr.io/linuxserver/docker-compose:latest}" "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,31 +1,24 @@
 #!/bin/sh
 #
-# Forked from https://github.com/docker/compose/blob/master/script/run/run.sh
-#
 # Run docker-compose in a container
 #
 # This script will attempt to mirror the host paths by using volumes for the
 # following paths:
-#   * $(pwd)
-#   * $(dirname $COMPOSE_FILE) if it's set
-#   * $HOME if it's set
+#   * ${PWD}
+#   * $(dirname ${COMPOSE_FILE}) if it's set
+#   * ${HOME} if it's set
 #
 # You can add additional volumes (or any docker run options) using
-# the $COMPOSE_OPTIONS environment variable.
+# the ${COMPOSE_OPTIONS} environment variable.
 #
-# You can set a specific image tag from Docker Hub, such as "1.26.2-ls9", or "alpine"
-# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "latest")
+# You can set a specific image and tag, such as "docker/compose:1.27.4", or "docker/compose:alpine-1.27.4"
+# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "docker/compose:1.27.4")
 #
-
 
 set -e
 
-# set image tag to latest if not globally set
-DOCKER_COMPOSE_IMAGE_TAG="${DOCKER_COMPOSE_IMAGE_TAG:-latest}"
-IMAGE="ghcr.io/linuxserver/docker-compose:$DOCKER_COMPOSE_IMAGE_TAG"
-
 # Setup options for connecting to docker host
-if [ -z "$DOCKER_HOST" ]; then
+if [ -z "${DOCKER_HOST}" ]; then
     DOCKER_HOST='unix:///var/run/docker.sock'
 fi
 if [ -S "${DOCKER_HOST#unix://}" ]; then
@@ -34,47 +27,45 @@ else
     DOCKER_ADDR="-e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH"
 fi
 
-
 # Setup volume mounts for compose config and context
-if [ "$(pwd)" != '/' ]; then
-    VOLUMES="-v $(pwd):$(pwd)"
+if [ "${PWD}" != '/' ]; then
+    VOLUMES="-v ${PWD}:${PWD}"
 fi
-if [ -n "$COMPOSE_FILE" ]; then
-    COMPOSE_OPTIONS="$COMPOSE_OPTIONS -e COMPOSE_FILE=$COMPOSE_FILE"
-    compose_dir="$(dirname "$COMPOSE_FILE")"
+if [ -n "${COMPOSE_FILE}" ]; then
+    COMPOSE_OPTIONS="${COMPOSE_OPTIONS} -e COMPOSE_FILE=${COMPOSE_FILE}"
+    COMPOSE_DIR="$(dirname "${COMPOSE_FILE}")"
     # canonicalize dir, do not use realpath or readlink -f
     # since they are not available in some systems (e.g. macOS).
-    compose_dir="$(cd "$compose_dir" && pwd)"
+    COMPOSE_DIR="$(cd "${COMPOSE_DIR}" && pwd)"
 fi
-if [ -n "$COMPOSE_PROJECT_NAME" ]; then
-    COMPOSE_OPTIONS="-e COMPOSE_PROJECT_NAME $COMPOSE_OPTIONS"
+if [ -n "${COMPOSE_PROJECT_NAME}" ]; then
+    COMPOSE_OPTIONS="-e COMPOSE_PROJECT_NAME ${COMPOSE_OPTIONS}"
 fi
 # TODO: also check --file argument
-if [ -n "$compose_dir" ]; then
-    VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
+if [ -n "${COMPOSE_DIR}" ]; then
+    VOLUMES="${VOLUMES} -v ${COMPOSE_DIR}:${COMPOSE_DIR}"
 fi
-if [ -n "$HOME" ]; then
-    VOLUMES="$VOLUMES -v $HOME:$HOME -e HOME" # Pass in HOME to share docker.config and allow ~/-relative paths to work.
+if [ -n "${HOME}" ]; then
+    VOLUMES="${VOLUMES} -v ${HOME}:${HOME} -e HOME" # Pass in HOME to share docker.config and allow ~/-relative paths to work.
 fi
 
 # Only allocate tty if we detect one
 if [ -t 0 ] && [ -t 1 ]; then
-    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -t"
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
 fi
 
 # Always set -i to support piped and terminal input in run/exec
-DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
-
+DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
 
 # Handle userns security
-if docker info --format '{{json .SecurityOptions}}' 2>/dev/null | grep -q 'name=userns'; then
-    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS --userns=host"
+if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name=userns'; then
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} --userns=host"
 fi
 
 # Detect SELinux and add --privileged if necessary
-if docker info --format '{{json .SecurityOptions}}' 2>/dev/null | grep -q 'name=selinux'; then
-    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS --privileged"
+if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name=selinux'; then
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} --privileged"
 fi
 
 # shellcheck disable=SC2086
-exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${DOCKER_COMPOSE_IMAGE_TAG:-docker/compose:1.27.4}" "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# Forked from https://github.com/docker/compose/blob/master/script/run/run.sh
+#
 # Run docker-compose in a container
 #
 # This script will attempt to mirror the host paths by using volumes for the
@@ -11,8 +13,8 @@
 # You can add additional volumes (or any docker run options) using
 # the ${COMPOSE_OPTIONS} environment variable.
 #
-# You can set a specific image and tag, such as "docker/compose:1.27.4", or "docker/compose:alpine-1.27.4"
-# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "docker/compose:1.27.4")
+# You can set a specific image and tag, such as "ghcr.io/linuxserver/docker-compose:version-1.27.4", or "ghcr.io/linuxserver/docker-compose:alpine"
+# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "ghcr.io/linuxserver/docker-compose:latest")
 #
 
 set -e


### PR DESCRIPTION
Ref: https://github.com/docker/compose/pull/7846

> A few things here.
> 
> - Use `${BRACES}` on all variables (good formatting).
> - Use `${PWD}` instead of `$(pwd)` to rely on the environment instead of a subshell.
> - Allow users to define `DOCKER_COMPOSE_IMAGE_TAG` in their environment to select an image and version to run. Default to `docker/compose:1.27.4` if the user has not set a version. (`latest` seems to be 3 months old as of writing so I've changed this to `docker/compose:1.27.4`). This also allows users to use alternative images or registries such as ghcr.io if their preferred image is available on other registries.
> - Uppercase `COMPOSE_DIR` to be in-line with all other variables.
> - ~~Fix `shellcheck disable=SC2086` by quoting all variables in https://github.com/docker/compose/compare/master...nemchik:run.sh?expand=1#diff-7123de446b63ba53f37a8e092cafaaaeR67 which then requires adding `eval` to the beginning of the line so that it will be correctly expanded.~~ Reverted this as it caused other issues. It's fixable in bash, but I have not found a posix shell solution.
> - Update the script to work with SELinux enforced (mostly RHEL) (from https://github.com/linuxserver/docker-docker-compose/commit/2658740a07816ed118a314c32b12c2a2a1edae25#diff-1b0c2b516b83393edb7200ad5ff12181R65-R69 )
> 
> I have tested these changes on Ubuntu 20.04

Users will be required to set `DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:latest` or `DOCKER_COMPOSE_IMAGE_TAG=ghcr.io/linuxserver/docker-compose:alpine` in order to use our image.

Eventual goal: If the upstream PR is accepted we will not need to maintain a separate copy of the script and can instruct users to use the officially provided script and set the `DOCKER_COMPOSE_IMAGE_TAG` variable to use our image.