### PR TITLE
use a custom external trigger to check all arches

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -69,25 +69,38 @@ jobs:
             echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
             exit 0
           else
-            echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"
-            response=$(curl -iX POST \
-              https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-docker-compose/job/v2/buildWithParameters?PACKAGE_CHECK=false \
-              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
-            echo "**** Jenkins job queue url: ${response%$'\r'} ****"
-            echo "**** Sleeping 10 seconds until job starts ****"
-            sleep 10
-            buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
-            buildurl="${buildurl%$'\r'}"
-            echo "**** Jenkins job build url: ${buildurl} ****"
-            echo "**** Attempting to change the Jenkins job description ****"
-            curl -iX POST \
-              "${buildurl}submitDescription" \
-              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} \
-              --data-urlencode "description=GHA external trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              --data-urlencode "Submit=Submit"
-            echo "**** Notifying Discord ****"
-            TRIGGER_REASON="A version change was detected for docker-compose tag v2. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
-            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
-              "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
-              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Checking other arches. . .  ****"
+            ARM32_EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/armhf/APKINDEX.tar.gz" | tar -xz -C /tmp \
+              && awk '/^P:'"docker-cli-compose"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
+            ARM64_EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+              && awk '/^P:'"docker-cli-compose"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
+            if [ "${EXT_RELEASE}" = "${ARM32_EXT_RELEASE}" ] && [ "${EXT_RELEASE}" = "${ARM64_EXT_RELEASE}" ]; then
+              echo "**** All arches have the latest package pushed, triggering build ****"
+              response=$(curl -iX POST \
+                https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-docker-compose/job/v2/buildWithParameters?PACKAGE_CHECK=false \
+                --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
+              echo "**** Jenkins job queue url: ${response%$'\r'} ****"
+              echo "**** Sleeping 10 seconds until job starts ****"
+              sleep 10
+              buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
+              buildurl="${buildurl%$'\r'}"
+              echo "**** Jenkins job build url: ${buildurl} ****"
+              echo "**** Attempting to change the Jenkins job description ****"
+              curl -iX POST \
+                "${buildurl}submitDescription" \
+                --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} \
+                --data-urlencode "description=GHA external trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+                --data-urlencode "Submit=Submit"
+              echo "**** Notifying Discord ****"
+              TRIGGER_REASON="A version change was detected for docker-compose tag v2. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+              curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+                "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
+                "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            else
+              echo "**** Not all arch repos are updated yet, skipping trigger ****"
+              FAILURE_REASON="New version ${EXT_RELEASE} for docker-compose tag v2 is detected, however not all arch repos are updated yet. Will try again in 1 hr."
+              curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+                "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+                "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            fi
           fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE .editorconfig ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE/config.yml ./.github/ISSUE_TEMPLATE/issue.bug.md ./.github/ISSUE_TEMPLATE/issue.feature.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/external_trigger_scheduler.yml ./.github/workflows/greetings.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/stale.yml ./.github/workflows/external_trigger.yml ./.github/workflows/package_trigger.yml'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE .editorconfig ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE/config.yml ./.github/ISSUE_TEMPLATE/issue.bug.md ./.github/ISSUE_TEMPLATE/issue.feature.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/external_trigger_scheduler.yml ./.github/workflows/greetings.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -6,6 +6,7 @@ external_type: alpine_repo
 release_type: prerelease
 release_tag: v2
 ls_branch: v2
+custom_external_trigger: true
 repo_vars:
   - CONTAINER_NAME = 'docker-compose'
   - BUILD_VERSION_ARG = 'COMPOSE_VERSION'


### PR DESCRIPTION
The dev and PR builds for this will fail due to the aarch64 repo not yet having the latest version. Once merged, the v2 live build will also likely fail, but that's ok. As long as the jenkinsfile and the trigger are updated, it won't trigger another build until all arch repos are updated. 

The downside is, if we ever change this to pull from a different repo (other than edge/community), we'll have to update the external trigger manually.