### PR TITLE
fix alpine branch name in custom external trigger

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -74,7 +74,7 @@ jobs:
             exit 0
           else
             echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Checking other arches. . .  ****"
-            ARM32_EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/armhf/APKINDEX.tar.gz" | tar -xz -C /tmp \
+            ARM32_EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/armv7/APKINDEX.tar.gz" | tar -xz -C /tmp \
               && awk '/^P:'"docker-cli-compose"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
             ARM64_EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp \
               && awk '/^P:'"docker-cli-compose"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')


### PR DESCRIPTION
all builds are going to fail, but it will at least fix the trigger so it doesn't fire off a build every hour until the package for armv7 is uploaded